### PR TITLE
refactor: 파일 처리 로직 FileUtil로 분리 및 컨트롤러 응답 수정 (30m)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ file:
 ## 로컬 환경 (H2)
 
 ### 2. 애플리케이션 실행 (로컬 환경)
-로컬 개발 및 테스트 환경에서는 H2 인메모리 데이터베이스를 사용합니다.
+로컬 개발 및 테스트 환경에서는 H2 인메모리 데이터베이스를 사용합니다.  
+JDK 17로 빌드되고 실행됩니다. Project Structure에서 Project, Modules에서 17을 설정합니다.
 
 ```bash
 ./gradlew bootRun --args='--spring.profiles.active=local'

--- a/src/main/java/com/pji/noticeboard/controller/NoticeController.java
+++ b/src/main/java/com/pji/noticeboard/controller/NoticeController.java
@@ -9,6 +9,7 @@ import com.pji.noticeboard.exception.ErrorResponse;
 import com.pji.noticeboard.service.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -163,7 +164,8 @@ public class NoticeController {
             })
     @GetMapping
     public ResponseEntity<Page<NoticeResponseDto>> getAllNotices(
-            @Parameter(description = "페이징 및 정렬 정보. 예시: ?page=0&size=10&sort=createdDate,desc")
+            @Parameter(description = "페이징 및 정렬 정보. 예시: ?page=0&size=10&sort=createdDate,desc",
+                    example = "{\"page\":0,\"size\":10,\"sort\":[\"createdDate,desc\"]}")
             @PageableDefault(size = 10) Pageable pageable) {
         Page<NoticeResponseDto> notices = noticeService.getAllNotices(pageable);
         return ResponseEntity.ok(notices);
@@ -178,7 +180,7 @@ public class NoticeController {
      */
     @Operation(summary = "조회수 상위 5개 공지사항 조회", description = "조회수가 가장 높은 5개의 공지사항을 조회합니다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회수 상위 공지사항 목록 조회 성공", content = @Content(schema = @Schema(implementation = List.class))),
+                    @ApiResponse(responseCode = "200", description = "조회수 상위 공지사항 목록 조회 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = NoticeResponseDto.class)))),
                     @ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping("/top")

--- a/src/main/java/com/pji/noticeboard/exception/ErrorCode.java
+++ b/src/main/java/com/pji/noticeboard/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     NOTICE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create notice"),
     NOTICE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to update notice"),
     NOTICE_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete notice"),
-    SAVE_FILE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to save file");
+    SAVE_FILE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to save file"),
+    INVALID_FILE_PROVIDED(HttpStatus.BAD_REQUEST, "Invalid file provided");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/pji/noticeboard/util/FileUtil.java
+++ b/src/main/java/com/pji/noticeboard/util/FileUtil.java
@@ -1,0 +1,95 @@
+package com.pji.noticeboard.util;
+
+import com.pji.noticeboard.exception.ErrorCode;
+import com.pji.noticeboard.exception.ServiceException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class FileUtil {
+
+    @Value("${file.upload.base-path}")
+    private String basePath;
+
+    /**
+     * 파일 목록을 처리하고 파일 시스템에 저장합니다.
+     *
+     * @param files 처리할 MultipartFile 객체의 목록
+     * @param title 로깅을 위한 공지사항 제목
+     * @return 저장된 파일 경로의 목록
+     */
+    public List<String> processFiles(List<MultipartFile> files, String title) {
+        return files.stream()
+                .map(file -> {
+                    try {
+                        return saveFile(file);
+                    } catch (IllegalArgumentException e) {
+                        log.error("Invalid file provided for notice with TITLE {}. Reason: {}", title, e.getMessage());
+                        throw new ServiceException(String.format("Invalid file provided for notice with TITLE %s. Reason: %s", title, e.getMessage()), ErrorCode.INVALID_FILE_PROVIDED, e);
+                    } catch (Exception e) {
+                        log.error("Failed to saveFile with TITLE {}", title, e);
+                        throw new ServiceException(String.format("Failed to saveFile with TITLE %s", title), ErrorCode.SAVE_FILE_FAILED, e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 파일 시스템에 파일을 저장합니다.
+     *
+     * @param file 저장할 MultipartFile 객체
+     * @return 파일이 저장된 경로
+     * @throws IOException I/O 오류가 발생한 경우
+     */
+    private  String saveFile(MultipartFile file) throws IOException {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("File must not be empty");
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !FileExtension.isValid(getFileExtension(originalFilename))) {
+            throw new IllegalArgumentException("Invalid file type");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        String dateFolder = now.format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+        File uploadDir = new File(basePath, dateFolder);
+
+        if (!uploadDir.exists() && !uploadDir.mkdirs()) {
+            throw new IOException("Failed to create directory: " + uploadDir.getAbsolutePath());
+        }
+
+        String fileName = now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + "_" + originalFilename;
+        File destinationFile = new File(uploadDir, fileName);
+
+        try {
+            file.transferTo(destinationFile);
+        } catch (IOException e) {
+            throw new IOException("Failed to save file", e);
+        }
+
+        return Paths.get(dateFolder, fileName).toString();
+    }
+
+    /**
+     * 파일의 확장자를 가져옵니다.
+     *
+     * @param filename 파일 이름
+     * @return 파일 확장자
+     */
+    private String getFileExtension(String filename) {
+        int dotIndex = filename.lastIndexOf(".");
+        return (dotIndex == -1) ? "" : filename.substring(dotIndex + 1);
+    }
+}

--- a/src/test/java/com/pji/noticeboard/service/NoticeServiceUnitTest.java
+++ b/src/test/java/com/pji/noticeboard/service/NoticeServiceUnitTest.java
@@ -7,6 +7,7 @@ import com.pji.noticeboard.dto.NoticeResponseDto;
 import com.pji.noticeboard.dto.NoticeUpdateDto;
 import com.pji.noticeboard.entity.Notice;
 import com.pji.noticeboard.repository.NoticeRepository;
+import com.pji.noticeboard.util.FileUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,6 +51,9 @@ class NoticeServiceUnitTest {
 
     @Mock
     private NoticeRepository noticeRepository;
+
+    @Mock
+    private FileUtil fileUtil;
 
     @InjectMocks
     private NoticeService noticeService;
@@ -118,6 +122,15 @@ class NoticeServiceUnitTest {
                 .build();
 
         when(noticeRepository.save(any(Notice.class))).thenReturn(notice);
+
+        doAnswer(invocation -> {
+            List<MultipartFile> providedFiles = invocation.getArgument(0);
+            String providedTitle = invocation.getArgument(1);
+
+            assertEquals(2, providedFiles.size());
+            assertEquals("New Title", providedTitle);
+            return null;
+        }).when(fileUtil).processFiles(files, noticeCreateDto.getTitle());
 
         Notice createdNotice = noticeService.createNotice(noticeCreateDto, files);
 


### PR DESCRIPTION
-생성, 수정 공지사항의 파일 처리 로직 FileUtil
-컨트롤러 응답 수정